### PR TITLE
Zurb Foundation skeleton

### DIFF
--- a/community/skeletons.html.md.eco
+++ b/community/skeletons.html.md.eco
@@ -21,7 +21,7 @@ These skeletons are currently under construction:
 
 - [Website Skeleton](https://github.com/docpad/website.docpad) `branch: docpad-6.x` - Website skeleton for DocPad. Useful for personal websites and blogs. Pulls in social streams and github information
 - [Syte](https://github.com/docpad/syte.docpad) `branch: master` - A simple pre-made personal website with blogging and social integrations.
-
+- [Zurb Foundation] (https://github.com/axyz/zurb-foundation.docpad) `branch: master` - [Zurb Foundation](https://github.com/zurb/foundation) skeleton for [DocPad](https://github.com/bevry/docpad)
 
 
 ### Older


### PR DESCRIPTION
added my zurb foundation skeleton in the experimental section

It is just an initial commit, it works and compile the sass source of foundation (but livereloads do not always work and it is quite slow to compile, but i would like to avoid to use a static version of zurb foundation because of the possibility to change its settings during the work).

I am not an expert of docpad, but i think it would be adviceable to add some page and blog post generation using docpad api.
