### PR TITLE
Link to line 1 of code example to skip github.com header.

### DIFF
--- a/core/events.html.md
+++ b/core/events.html.md
@@ -219,4 +219,20 @@ Called just after we finished setting up the server. Often used to extend the se
 Called just while we are setting up the server, and just before the DocPad routes are applied. Used to extend the server with routes that will be triggered before the DocPad routes. Options:
 - `server` the [express.js](http://expressjs.com/) server instance we are using
 
-Example: [The basicAuth Plugin](https://github.com/mikeumus/docpad-plugin-basicauth/blob/master/basicauth.plugin.coffee#L1) uses 'serverExtend' to add express' basicAuth to a route.
+Example: [The basicAuth Plugin](https://github.com/mikeumus/docpad-plugin-basicauth/blob/master/basicauth.plugin.coffee#L10) uses 'serverExtend' to add express' basicAuth to a route:
+```coffeescript
+serverExtend: (opts) ->
+	{express,server} = opts
+	{config,docpad} = @
+	# docpad = @docpad
+
+	# Synchronous
+	auth = express.basicAuth(dConf.basicAuth.user, dConf.basicAuth.pass)
+
+	server.get dConf.basicAuth.protectedPage, auth
+
+	# Done
+	@
+```
+
+


### PR DESCRIPTION
Linking pygments plugin to line 1 of github source code to skip github.com header. 

Adding example to serverExtend. 
