### PR TITLE
Patch 3

### DIFF
--- a/core/debug.html.md
+++ b/core/debug.html.md
@@ -20,9 +20,9 @@ Sometimes things go bad and you need to get into DocPad and work out what's happ
 
 1. Run:
 
-        ``` bash
-        node-inspector &
-        ```
+    ``` bash
+    node-inspector &
+    ```
 
 1. Open another terminal window and run DocPad instance in debug mode:
 
@@ -31,8 +31,8 @@ Sometimes things go bad and you need to get into DocPad and work out what's happ
 	```
 
 1. Navigate to http://127.0.0.1:8080/debug?port=5858 in your webkit based browser and start debugging (sometimes you may have to refresh or restart the node inspector or docpad instances).
-
-1. **NOTE**: It might break on the first line of docpad.js , ensure that you play it through or else the docpad server will not be started properly
+   
+   1. **NOTE**: It might break on the first line of `docpad.js` file, ensure that you play it through or else the docpad server will not start.
 
 ## Debugging with [TraceGL](https://trace.gl/) - shareware
 


### PR DESCRIPTION
Repeat of my answer to @Greduan:

After step 4, I realise that my docpad instance is not accessible and it took me few seconds to find that it breaks on the first line.

This is because `docpad-debug` will execute `node --debug-brk --prof docpad run` so I thought that we can add a small note on this
