### PR TITLE
Add the htmlmin plugin

### DIFF
--- a/community/plugins.html.md
+++ b/community/plugins.html.md
@@ -24,6 +24,7 @@ These are plugins that add support for extra markups and languages to DocPad:
 - [hogan](/plugin/hogan/) - Supports [Hogan/Mustache](http://twitter.github.com/hogan.js/) to anything `.anything.hogan`
 - [html2coffee](/plugin/html2coffee/) - Supports HTML to CoffeeKup `.coffee.html`
 - [html2jade](/plugin/html2jade) - Supports HTML to [Jade](http://jade-lang.com/) `.jade.html`
+- [htmlmin](http://github.com/robloach/docpad-plugin-htmlmin) - Supports minifying HTML with [HTML-Minifier](http://kangax.github.io/html-minifier/) `.html.htmlmin.anything`
 - [jade](/plugin/jade/) - Supports [Jade](http://jade-lang.com/) to anything `.anything.jade`
 - [js2coffee](/plugin/js2coffee/) - Supports JavaScript to CoffeeScript `.coffee.js`
 - [less](/plugin/less/) - Supports [LessCSS](http://lesscss.org/) to CSS `.css.less`


### PR DESCRIPTION
Add [docpad-plugin-htmlmin](https://github.com/robloach/docpad-plugin-htmlmin) to the list of plugins. It uses [http://kangax.github.io/html-minifier/](html-minifier) to minify HTML.

``` bash
$ docpad install htmlmin
```
