### PR TITLE
Update skeletons.html.md.eco

### DIFF
--- a/community/skeletons.html.md.eco
+++ b/community/skeletons.html.md.eco
@@ -22,7 +22,6 @@ Want to add yours? [Add it to the listing here.](https://github.com/bevry/docpad
 These skeletons are currently under construction:
 
 - [Syte](https://github.com/docpad/syte.docpad) `branch: master` - A simple pre-made personal website with blogging and social integrations.
-- [Zurb Foundation] (https://github.com/axyz/zurb-foundation.docpad) `branch: master` - [Zurb Foundation](https://github.com/zurb/foundation) skeleton for [DocPad](https://github.com/bevry/docpad)
 
 
 ### Older


### PR DESCRIPTION
Remove experimental "Zurb Foundation" since it is now listed among the "current" skeletons under the name "Zurb Foundation(SASS)"
