### PR TITLE
Update 03-begin.html.md

### DIFF
--- a/01-start/03-begin.html.md
+++ b/01-start/03-begin.html.md
@@ -321,7 +321,7 @@ Open the Stylesheet document we created earlier (`documents/styles/style.css`). 
 
 Install the [Stylus Plugin](/plugin/stylus) by running `docpad install stylus`.
 
-Then, rename `src/files/styles/style.css` to `src/files/styles/style.css.styl`, to indicate we want to render from Stylus to CSS, and open it. 
+Then, rename `src/documents/styles/style.css` to `src/documents/styles/style.css.styl`, to indicate we want to render from Stylus to CSS, and open it. The reason why we created the style file in `documents` and not in `files` is now obvious: if the stylus stylesheet file were in `files/styles/` folder, it would not have been pre-processed before copying to `out`.
 
 Using Stylus syntax, update the stylesheet's content to become:
 


### PR DESCRIPTION
The tutorial incorrectly suggests renaming the file `/files/styles/style.css.styl`, while the file was added in /documents folder in a previous step.
