### PR TITLE
permission-errors

### DIFF
--- a/01-start/06-troubleshoot.html.md
+++ b/01-start/06-troubleshoot.html.md
@@ -17,7 +17,7 @@ sudo chown -R $USER /usr/local ~/.npm
 chmod -R 755 ~/.npm
 ```
 
-Be sure that you tmp dir is writable for the current user:
+Be sure that your tmp dir is writable for the current user:
 
 ``` bash
 sudo chown -R $USER:$GROUPS ~/tmp


### PR DESCRIPTION
**permission errors solution added 522acd03386b68a471193407d0924321a323c816**
Sometimes when you install a npm package with sudo, the ~/tmp dir will have the owner `root`. This is the reason when installing/updating docpad or any other npm package that uses temporary files, results in permission errors.

**alter system files removed a59abda9975aacc9437e1c23327b71f666cca2eb**
I think it's rather dangerous to change the user of system files and make them writable.
