### PR TITLE
Updated the website showcase with Boundstar.

### DIFF
--- a/community/showcase.html.md
+++ b/community/showcase.html.md
@@ -48,6 +48,7 @@ Websites built with DocPad. Alphabetically sorted.
 - [Ben Dellare](http://www.delarre.net/) - [source](https://github.com/benjamind/delarre.docpad) - Coder, maker, hacker, infrequent blogger.
 - [Benjamin Lupton](http://balupton.com) - [source](https://github.com/balupton/balupton.docpad) - Founder of [Bevry](http://bevry.me), [DocPad](http://docpad.org), [History.js](http://historyjs.net) and [StartupHostel](http://startuphostel.org). Liberating and empowering the world by making your dreams more accessible.
 - [Black Market](http://blackmarket.bg/) - Bulgarian fashion company
+- [Boundstar](http://boundstar.com) - Website for a public Starbound game server.
 - [chrisbuchholz.me](http://chrisbuchholz.me/) - [source](https://github.com/ChrisBuchholz/chrisbuchholz.github.com) - Personal website of chrisbuchholz
 - [CoApp](http://coapp.org/) - [source](https://github.com/coapp/coapp.org) - CoApp is an open-source package management system for Windows
 - [DataTables Taglib](http://tduchateau.github.com/DataTables-taglib/) - [source](https://github.com/tduchateau/DataTables-taglib/tree/gh-pages) - Website of DataTables-taglib, a JSP taglib that allows to quickly create [DataTables](http://datatables.net) in Java/JEE based web application


### PR DESCRIPTION
I would like to add this website I created at the start of this year to the list. It uses git-hooks and integrates with https://github.com/seriallos/commandstar to show a realtime players list.
