### PR TITLE
Fixed “its” and “it’s” to correct usage

### DIFF
--- a/01-start/05-faq.html.md
+++ b/01-start/05-faq.html.md
@@ -13,7 +13,7 @@ Whenever we write something we're using markup. It's merely a way of formatting 
 
 For instance, **bold** in Markdown is `**bold**`, where in HTML it is `<strong>bold</strong>`. The markup that you choose for your content is highly dependent on what content you'd like to write. If you're mostly dealing with structural data (like a page layout) then `HTML`, `Jade`, `Haml`, or `CoffeeKup` would be a good way to go. If you're mostly dealing with textual data (like a blog post) then `Markdown` would probably the way to go.
 
-DocPad supports unlimited markups thanks to its plugin system. It doesn't believe in a one size fits all, but in always using the best tool for a job. Its easy to learn new markups, there may be a bit of a learning curve, but you'll quickly adjust, be empowered, and grateful that you now have a new tool under your belt.
+DocPad supports unlimited markups thanks to its plugin system. It doesn't believe in a one size fits all, but in always using the best tool for a job. It's easy to learn new markups, there may be a bit of a learning curve, but you'll quickly adjust, be empowered, and grateful that you now have a new tool under your belt.
 
 DocPad currently only supports rendering plain-text formats, meaning that rendering binary formats like `img` to `jpg` or binary-text formats like `doc` to `rtf` (they're not plain-text formats like `txt`, `docx`, or `xml` but in fact binary formats) does not currently work. [We will be addressing this in a future release of DocPad.](https://github.com/bevry/docpad/issues/684)
 
@@ -49,7 +49,7 @@ title: "My awesome blog post"
 That is your document's meta data. It won't be included in the output of the document, and is where you can assign extra data to your document such as title, date, tags, etc.
 
 
-## Is a document aware of it's meta data?
+## Is a document aware of its meta data?
 
 It sure is, if you are using eco as the rendering engine, you can totally do this:
 

--- a/01-start/06-troubleshoot.html.md
+++ b/01-start/06-troubleshoot.html.md
@@ -108,7 +108,7 @@ There are a few things you can do:
 
 
 ### Whenever I output a variable (like `content`) it is escaped (`<` rendered as `&lt;`)?
-Template engines by default _escape_ all variable output. Escaping is when we turn things like the open bracket `<` into it's _html entity_ equivalent `&lt;`. This helps prevent malicious code accidentally being injected into your website which can open the door to XSS attacks. As such, we have to use a special syntax to keep the variable _unescaped_ when outputted. The special syntax is different for the templating engine your using, so here are the ways we know:
+Template engines by default _escape_ all variable output. Escaping is when we turn things like the open bracket `<` into its _html entity_ equivalent `&lt;`. This helps prevent malicious code accidentally being injected into your website which can open the door to XSS attacks. As such, we have to use a special syntax to keep the variable _unescaped_ when outputted. The special syntax is different for the templating engine your using, so here are the ways we know:
 
 - Eco: `<%- content %>` instead of `<%= content %>`
 - Jade: `!= content` instead of `= content`

--- a/01-start/08-upgrade.html.md
+++ b/01-start/08-upgrade.html.md
@@ -65,7 +65,7 @@ To upgrade your DocPad installation from an older version to the latest, check o
 
 2. For plugin developers, the way you extend from the `BasePlugin`, and the way you `module.exports` your plugin has changed. [To learn about the new convention, refer to the new _Extending_ guide by clicking here.](/docpad/extend)
 
-3. For those using DocPad as a module, DocPad now supports a `next` callback on it's constructor, allowing you to do `new DocPad(config,next)`. Anything that depends on a DocPad action being completed should go inside the `next` callback. While this is optional, it has provided helpful in eliminating timing problems.
+3. For those using DocPad as a module, DocPad now supports a `next` callback on its constructor, allowing you to do `new DocPad(config,next)`. Anything that depends on a DocPad action being completed should go inside the `next` callback. While this is optional, it has provided helpful in eliminating timing problems.
 
 ## Upgrading from 1.x to 2.x
 
@@ -73,7 +73,7 @@ To upgrade your DocPad installation from an older version to the latest, check o
 2. For plugin developers:
 	1. Plugins have been revised to become more future proof and configurable. Plugins must be in their own directory, with the following format: `plugins/${pluginName}/${pluginName}.plugin.coffee`
 	2. Plugin dependencies should no longer be in the docpad's or your project's `package.json` file, but instead in their plugin directory's `package.json` - e.g. `plugins/${pluginName}/package.json` - this file is optional, but recommended.
-	3. If a plugin's `package.json` exists, as well as it's `main` property, docpad will use that as the plugin file's location instead of the location in step 2.1.
+	3. If a plugin's `package.json` exists, as well as its `main` property, docpad will use that as the plugin file's location instead of the location in step 2.1.
 	4. Plugin configuration should be moved to their `package.json` file, to the key `docpad.plugin` which should be an object. This is then customisable by docpad's `package.json` as well as the website's via `docpad.plugin.#{pluginName}`. The configuration of a plugin is available via the `@config` property.
 	5. To access docpad within a plugin, you should now use `@docpad` rather than having it passed through as an argument, this applies for logger too (now use `@logger`).
 	6. A lot of docpad configuration has been moved to `@docpad.config`

--- a/community/participate.html.md.eco
+++ b/community/participate.html.md.eco
@@ -27,7 +27,7 @@ You can get chatting with anyone who's around by visiting the IRC channel `#docp
 
 
 ### Priority Focus
-Each month, we do a sprint bundled with new features from the roadmap and bugs from the issue tracker. We will always aim to get high priority bugs fixed and released as soon as posible. Once the bugs are all done, then we focus on the new features. When a feature is done, we release it to the public right away and then test and validate it's value to the community. Once a feature has been proven to be valuable, we close it. You can read more about this process in the book [The Lean Startup](http://theleanstartup.com/).
+Each month, we do a sprint bundled with new features from the roadmap and bugs from the issue tracker. We will always aim to get high priority bugs fixed and released as soon as posible. Once the bugs are all done, then we focus on the new features. When a feature is done, we release it to the public right away and then test and validate its value to the community. Once a feature has been proven to be valuable, we close it. You can read more about this process in the book [The Lean Startup](http://theleanstartup.com/).
 
 
 #### On fixing bugs first
@@ -35,7 +35,7 @@ The focus on "bugs first, features later" is to ensure that the users of DocPad 
 
 
 #### Implement and release tasks independently of each other
-As we use the amazing git technology, there is a thing called branching, each new task (feature, bug, etc) to be done should be implemented in it's own branch. This prevents the feature from interfering with other features while you work on it. Once the feature is stable, a DocPad maintainer will pull it with the latest master branch and make sure it is still stable, then merge it into master branch and perform a release. This allows us to implement and release tasks independently on each other. So developers get immediate feedback, and users get immediate results - without any waiting! yay!
+As we use the amazing git technology, there is a thing called branching, each new task (feature, bug, etc) to be done should be implemented in its own branch. This prevents the feature from interfering with other features while you work on it. Once the feature is stable, a DocPad maintainer will pull it with the latest master branch and make sure it is still stable, then merge it into master branch and perform a release. This allows us to implement and release tasks independently on each other. So developers get immediate feedback, and users get immediate results - without any waiting! yay!
 
 <% if @getContributors().length: %>
 ## Contributors

--- a/core/config.html.md
+++ b/core/config.html.md
@@ -305,7 +305,7 @@ docpadConfig = {
 			# if we have a document title, then we should use that and suffix the site's title onto it
 			if @document.title
 				"#{@document.title} | #{@site.title}"
-			# if our document does not have it's own title, then we should just use the site's title
+			# if our document does not have its own title, then we should just use the site's title
 			else
 				@site.title
 

--- a/extend/plugin-write.html.md
+++ b/extend/plugin-write.html.md
@@ -23,7 +23,7 @@ module.exports = (BasePlugin) ->
 
 What this does is extends our BasePlugin from DocPad, and returns the `YourPlugin` class. Of course you should change the `YourPlugin` references to whatever your plugin is actually called.
 
-The [BasePlugin](https://github.com/bevry/docpad/blob/master/src/lib/plugin.coffee) is important as it provides some of the tucked away magic for our plugins. But what is even more important, is the plugin events that your plugin will hook into to provide it's functionality. [You can discover the plugin events available to you on the Events Page.](/docpad/events)
+The [BasePlugin](https://github.com/bevry/docpad/blob/master/src/lib/plugin.coffee) is important as it provides some of the tucked away magic for our plugins. But what is even more important, is the plugin events that your plugin will hook into to provide its functionality. [You can discover the plugin events available to you on the Events Page.](/docpad/events)
 
 If you must insist on writing your plugin inside a non-coffeecript dialect, you may use the `BasePlugin.extend({})` method like so:
 
@@ -106,7 +106,7 @@ Plugins of other types are generated in the same way as Renderers, they simply a
 
 ## Reusable plugins
 
-If you are just adding some basic functionality that is specific to a site then everything we've described thus far is probably enough. However if you're doing something thats more generic, or could be useful to other people, then why not create your plugin so its reusable? This has many advantages, you can distribute your plugin on NPM, you can use it across multiple projects, and you can setup unit tests to ensure your plugin works correctly.
+If you are just adding some basic functionality that is specific to a site then everything we've described thus far is probably enough. However if you're doing something thats more generic, or could be useful to other people, then why not create your plugin so it's reusable? This has many advantages, you can distribute your plugin on NPM, you can use it across multiple projects, and you can setup unit tests to ensure your plugin works correctly.
 
 Here's the extra files that we will need to add to our plugin:
 


### PR DESCRIPTION
Okay, so my giant pull requests from ages ago are still open, and now horribly out of date.  I’ll start making these PRs smaller. :)
