### PR TITLE
Updated all instances where node js 0.10 was recommended as current supported version

### DIFF
--- a/01-start/01-install.html.md.eco
+++ b/01-start/01-install.html.md.eco
@@ -5,7 +5,7 @@ _If you are upgrading from one major version to another (e.g., DocPad v5 to DocP
 
 1. [Install Node.js & Other Dependencies](/node/install)
 
-	DocPad works best with the latest stable Node.js version installed (currently Node.js v0.10). If you're still running the older Node v0.8, we'd recommend upgrading using the instructions above to get the best experience. You can find out what Node.js version you are running with the command: `node --version`
+	DocPad works best with the latest stable Node.js version installed (currently io.js or Node.js v0.12). If you're still running Node v0.10 (or even v0.8), we'd recommend upgrading using the instructions above to get the best experience. You can find out what Node.js version you are running with the command: `node --version`
 
 1. Update NPM and Install DocPad
 


### PR DESCRIPTION
Updated the recommended version of node.js to use with docpad. (I did a bunch of grepping and only found one instance that needed to be updated.)

Feel free to make suggestions about the new wording. In particular, not sure about calling io.js a stable version, or if we should indicate the exact version of io.js. I am just not sure about what level of support we have for io.js.