### PR TITLE
Proofread troubleshooting

### DIFF
--- a/01-start/06-troubleshoot.html.md
+++ b/01-start/06-troubleshoot.html.md
@@ -38,7 +38,7 @@ If that fails, we'd recommend either:
 
 ### When I run `npm install` on windows, I get `gyp ERR! configure error`
 - For Windows XP/Vista/7 installations:
-  - [Python](http://www.python.org/download/) [v2.7.3](http://www.python.org/download/releases/2.7.3#download) Recommended 
+  - [Python](http://www.python.org/download/) [v2.7.8](http://www.python.org/download/releases/2.7.8#download) Recommended 
   - [Microsoft Visual Studio C++ 2010](http://go.microsoft.com/?linkid=9709949)
 - For 64-bit builds of Node.js and native modules, you'll also need:
   - [Windows 7 64-bit SDK](http://www.microsoft.com/en-us/download/details.aspx?id=8279)

--- a/01-start/06-troubleshoot.html.md
+++ b/01-start/06-troubleshoot.html.md
@@ -79,7 +79,7 @@ This will introduce problems however if you have previously customised `watchOpt
 
 
 ### Error: "We couldn't find an existing DocPad project inside your current directory..."
-This occurs when you run `docpad run` inside a directory that already has existing files, but doesn't have a structure that resembles a DocPad project. We can't directly ask you if you would like to use an existing [skeleton](/docpad/skeletons) for the basis of your new website, as pulling in a skeleton inside a non-empty directory may overwrite your existing files. If would like to still use a skeleton for the basis of your new website, you will have to run DocPad inside a new empty directory. If you would like to start your website from scratch (not use an existing skeleton) then you can follow the [Getting Started](/docpad/start) guide. Hope that helps :) [If you need more help then check out our Support Channels](/support).
+This occurs when you run `docpad run` inside a directory that already has existing files, but doesn't have a structure that resembles a DocPad project. We can't directly ask you if you would like to use an existing [skeleton](/docpad/skeletons) for the basis of your new website, as pulling in a skeleton inside a non-empty directory may overwrite your existing files. If would like to still use a skeleton for the basis of your new website, you will have to run DocPad inside a new empty directory. If you would like to start your website from scratch (not use an existing skeleton) then you can follow the [Getting Started](/docpad/start) guide. Hope that helps :) [If you need more help then check out our Support Channels](https://discuss.bevry.me/t/getting-support-guide/63/1).
 
 
 ### Error: "Could not locate git binary"
@@ -117,7 +117,7 @@ Template engines by default _escape_ all variable output. Escaping is when we tu
 - Haml: `!= content` instead of `= content`
 
 ### The output of a variable (like `document.title`) is empty or `null`
-Be sure that you use the correct syntax for your template language, read the documentation of your chosen language.  
+Be sure that you use the correct syntax for your template language. Refer to the documentation of your chosen language.
 For example: When you want to put the output of a variable into the content of an (HTML) element in Jade, you must not write a whitespace between the element and the `=`. So this is wrong: `title = document.title` and that is correct: `title= document.title`
 
 
@@ -142,4 +142,4 @@ The Jade compiler uses the full file content on the disk to show where the parsi
 ## Need more help?
 
 - Found a bug? [File a Bug Report on the Issue Tracker](/issues)
-- Need support? [Check out our Support Channels](/support)
+- Need support? [Check out our Support Channels](https://discuss.bevry.me/t/official-bevry-support-channels/63/1)


### PR DESCRIPTION
A couple things here. Proofreading + updated links to /support.

I recommended python 2.7.8. It was on 2.7.3. I didn't go all the way to 2.7.9, since some people have complained vociferously about breakage of their SSL modules. I am not sure, really, if we should be recommending a specific minor version, since it changes often.