### PR TITLE
fix invalid agument

### DIFF
--- a/01-start/01-install.html.md.eco
+++ b/01-start/01-install.html.md.eco
@@ -16,7 +16,7 @@ _If you are upgrading from one major version to another (e.g. DocPad v5 to DocPa
 
 	**Note:** If you encounter permission errors with the above, do not use `sudo`, in our experience using `sudo` with node only creates further issues (regardless of DocPad). Follow our Step 1 instructions for a way to install Node with permissions that never require the use of `sudo`.
 	
-	You can verify DocPad has installed correctly by using `docpad -v` to output DocPad's version number.
+	You can verify DocPad has installed correctly by using `docpad -V` to output DocPad's version number.
 
 1. **When upgrading:** in addition to the above, run `docpad update` inside your project directory to ensure that your local installation of DocPad and its plugins are updated to their latest compatible versions,
 


### PR DESCRIPTION
`docpad -v` produces `error: unknown option ``-v'`. The correct argument is `-V`