### PR TITLE
Changed http://localhost:9778/about.html to embedded html link

### DIFF
--- a/01-start/03-begin.html.md
+++ b/01-start/03-begin.html.md
@@ -74,7 +74,7 @@ Now that's done, we'll want to add our "About Me" page so that people browsing o
 </html>
 ```
 
-Now if we go to [http://localhost:9778/about.html](http://localhost:9778/about.html), we'll be able to see that page in our browser. Awesome!
+Now if we go to <a href="http://localhost:9778/about.html" rel="nofollow">http://localhost:9778/about.html</a>, we'll be able to see that page in our browser. Awesome!
 
 However, duplicating that layout information inside our _Homepage_ and our _About_ page is pretty redundant. For instance, if we wanted to change the contents of `<head>` to something else, then we'll have to change it in two places! This is where layouts come in.
 

--- a/01-start/07-support.html.md.eco
+++ b/01-start/07-support.html.md.eco
@@ -50,7 +50,7 @@ For documentation suggestions, issues, and pull requests use [DocPad's Documenta
 
 DocPad operates a the `#docpad` channel on the freenode IRC server. It is a place where you can talk in realtime to other people all about DocPad and try and get support.
 
-[Join the IRC chat room.](irc://chat.freenode.net:6997/docpad)
+<a href="irc://chat.freenode.net:6997/docpad" rel="nofollow">Join the IRC chat room.</a>
 
 [Don't have an IRC Client? Join the web chat room instead.](http://webchat.freenode.net/?channels=docpad)
 


### PR DESCRIPTION
Changed http://localhost:9778/about.html to embedded html link in order to add rel attribute with "nofollow" value as this is not a link to a real page. This link shouldn't be crawled by a search engine and also so that we can identify it as not being a broken link.